### PR TITLE
Fix for block commenting using wrong delimiters

### DIFF
--- a/scoped-properties/language-lua.cson
+++ b/scoped-properties/language-lua.cson
@@ -1,4 +1,5 @@
 '.source.lua':
   'editor':
+    'commentStart': '-- '
     'increaseIndentPattern': '\\b(else|elseif|(local\\s+)?function|then|do|repeat)\\b((?!end).)*$|\\{\\s*$'
     'decreaseIndentPattern': '^\\s*(elseif|else|end|\\})\\s*$'


### PR DESCRIPTION
Using comment keyboard shortcut will now use the correct delimiters.

Fixes #1.
