### PR TITLE
Fix indentation in functions inside tables

### DIFF
--- a/scoped-properties/language-lua.cson
+++ b/scoped-properties/language-lua.cson
@@ -2,4 +2,4 @@
   'editor':
     'commentStart': '-- '
     'increaseIndentPattern': '\\b(else|elseif|(local\\s+)?function|then|do|repeat)\\b((?!end).)*$|\\{\\s*$'
-    'decreaseIndentPattern': '^\\s*(elseif|else|end,?|\\}\\)?)\\s*$'
+    'decreaseIndentPattern': '^\\s*(elseif|else|end,?|\\}\\)?).*$'

--- a/scoped-properties/language-lua.cson
+++ b/scoped-properties/language-lua.cson
@@ -2,4 +2,4 @@
   'editor':
     'commentStart': '-- '
     'increaseIndentPattern': '\\b(else|elseif|(local\\s+)?function|then|do|repeat)\\b((?!end).)*$|\\{\\s*$'
-    'decreaseIndentPattern': '^\\s*(elseif|else|end|\\})\\s*$'
+    'decreaseIndentPattern': '^\\s*(elseif|else|end,?|\\}\\)?)\\s*$'


### PR DESCRIPTION
A code snippet like this would not have indented properly before, because ```end``` is followed by a comma.

```lua
lib.func(42, {
    callback = function(param)    
    end,
    option = true
})
```

It also now decreases indent, if a curly bracket is directly followed by a parenthesis.