### PR TITLE
Fix decrease indent on repeat until loop

### DIFF
--- a/settings/language-lua.cson
+++ b/settings/language-lua.cson
@@ -2,4 +2,4 @@
   'editor':
     'commentStart': '-- '
     'increaseIndentPattern': '\\b(else|elseif|(local\\s+)?function|then|do|repeat)\\b((?!end).)*$|\\{\\s*$'
-    'decreaseIndentPattern': '^\\s*(elseif|else|end,?|\\}\\)?).*$'
+    'decreaseIndentPattern': '^\\s*(elseif|else|end|until,?|\\}\\)?).*$'


### PR DESCRIPTION
Fixes the indentation of repeat until loop not decreasing when until written.
```lua
repeat
    -- code
until (cond)
```
