### PR TITLE
Change 'and', 'or' and 'not' to control instead of operator keyword

### DIFF
--- a/grammars/lua.cson
+++ b/grammars/lua.cson
@@ -130,7 +130,7 @@
     ]
   }
   {
-    'match': '\\b(break|do|else|for|if|elseif|return|then|repeat|while|until|end|function|local|in)\\b'
+    'match': '\\b(and|or|not|break|do|else|for|if|elseif|return|then|repeat|while|until|end|function|local|in)\\b'
     'name': 'keyword.control.lua'
   }
   {
@@ -148,10 +148,6 @@
   {
     'match': '(?<![^.]\\.|:)\\b(coroutine\\.(create|resume|running|status|wrap|yield)|string\\.(byte|char|dump|find|format|gmatch|gsub|len|lower|match|rep|reverse|sub|upper)|table\\.(concat|insert|maxn|remove|sort)|math\\.(abs|acos|asin|atan2?|ceil|cosh?|deg|exp|floor|fmod|frexp|ldexp|log|log10|max|min|modf|pow|rad|random|randomseed|sinh?|sqrt|tanh?)|io\\.(close|flush|input|lines|open|output|popen|read|tmpfile|type|write)|os\\.(clock|date|difftime|execute|exit|getenv|remove|rename|setlocale|time|tmpname)|package\\.(cpath|loaded|loadlib|path|preload|seeall)|debug\\.(debug|[gs]etfenv|[gs]ethook|getinfo|[gs]etlocal|[gs]etmetatable|getregistry|[gs]etupvalue|traceback))\\b(?=\\s*(?:[({"\']|\\[\\[))'
     'name': 'support.function.library.lua'
-  }
-  {
-    'match': '\\b(and|or|not)\\b'
-    'name': 'keyword.operator.lua'
   }
   {
     'match': '\\b([A-Za-z_]\\w*)\\b(?=\\s*(?:[({"\']|\\[\\[))'


### PR DESCRIPTION
Hi,

A small proposal to improve the syntax highlighting:
![screenshot 2015-05-18 04 14 10](https://cloud.githubusercontent.com/assets/11627131/7673522/5c1f4410-fd15-11e4-9f3e-4dd479a993ff.png)
![screenshot 2015-05-18 04 13 40](https://cloud.githubusercontent.com/assets/11627131/7673524/5e83ef44-fd15-11e4-8020-19593bcc158b.png)

Best wishes,
Robert