### PR TITLE
Fix highlighting for indented multiline comments

### DIFF
--- a/grammars/lua.cson
+++ b/grammars/lua.cson
@@ -113,7 +113,7 @@
     'name': 'comment.block.lua'
   }
   {
-    'begin': '(^[ \\t]+)?(?=--(?!\\[\\[))'
+    'begin': '(^[ \\t]+)?(?=--(?!\\[(=*)\\[))'
     'beginCaptures':
       '1':
         'name': 'punctuation.whitespace.comment.leading.lua'


### PR DESCRIPTION
Multiline comments of the form ```--[=[ ]=]``` (one or more ```=``` characters) were highlighted only if the start of the comment was not indented.

One of the patterns in ```grammars/lua.cson``` was missing ```=*```, but it should be fixed now.

**Before:**
![screenshot from 2015-05-18 16 28 06](https://cloud.githubusercontent.com/assets/3522333/7681923/ab9cdcb6-fd7c-11e4-908f-214e1eec6c50.png)

**After:**
![screenshot from 2015-05-18 16 30 07](https://cloud.githubusercontent.com/assets/3522333/7681924/b1b3d0a0-fd7c-11e4-98ff-e624afbd9ba5.png)