### PR TITLE
Improve syntax highlighting

### DIFF
--- a/grammars/lua.cson
+++ b/grammars/lua.cson
@@ -130,7 +130,7 @@
     ]
   }
   {
-    'match': '\\b(and|or|not|break|do|else|for|if|elseif|return|then|repeat|while|until|end|function|local|in)\\b'
+    'match': '\\b(and|or|not|break|do|else|for|if|elseif|return|then|repeat|while|until|end|function|local|in|goto)\\b'
     'name': 'keyword.control.lua'
   }
   {

--- a/grammars/lua.cson
+++ b/grammars/lua.cson
@@ -24,6 +24,15 @@
     'name': 'meta.function.lua'
   }
   {
+    "captures": {
+      "1": {
+        "name": "entity.name.type.class"
+      }
+    },
+    "match": "(\\b([A-Z][a-z_]+[A-Z]*)+\\b)",
+    "name": "entity.name.type.class.lua"
+  }
+  {
     'match': '(?<![\\d.])\\s0x[a-fA-F\\d]+|\\b\\d+(\\.\\d+)?([eE]-?\\d+)?|\\.\\d+([eE]-?\\d+)?'
     'name': 'constant.numeric.lua'
   }

--- a/grammars/lua.cson
+++ b/grammars/lua.cson
@@ -134,7 +134,7 @@
     'name': 'keyword.control.lua'
   }
   {
-    'match': '(?<![^.]\\.|:)\\b(false|nil|true|_G|_VERSION|math\\.(pi|huge))\\b|(?<![.])\\.{3}(?!\\.)'
+    'match': '(?<![^.]\\.|:)\\b([A-Z_]+|false|nil|true|math\\.(pi|huge))\\b|(?<![.])\\.{3}(?!\\.)'
     'name': 'constant.language.lua'
   }
   {


### PR DESCRIPTION
My attempt at making the syntax highlighting a bit nicer. Still Needs testing with different coding styles. I am not sure if this should be merged at all because it is tailored toward a pretty specific style.

Added highlighting for constants (follows style of Lua's default constants - i.e. UPPER_CASE)
![screenshot 2015-06-28 21 52 47](https://cloud.githubusercontent.com/assets/11627131/8397997/03ed73c0-1de0-11e5-9dbb-c082549e7985.png)

Added goto to the list of control keywords as discussed in #21:
![screenshot 2015-12-07 12 52 54](https://cloud.githubusercontent.com/assets/11627131/11626234/7df25f02-9ce1-11e5-9d61-dbfdb40dc998.png)

Added highlighting for class variables:
![screenshot 2016-01-05 01 33 59](https://cloud.githubusercontent.com/assets/11627131/12104518/941eb858-b34c-11e5-93c5-06c37620cf4d.png)