### PR TITLE
Improvements to the constant.character.escape matching

### DIFF
--- a/grammars/lua.cson
+++ b/grammars/lua.cson
@@ -5,6 +5,17 @@
 ]
 'firstLineMatch': '\\A#!.*?\\blua\\b'
 'name': 'Lua'
+'repository':
+  'characterEscape':
+    'patterns': [
+      {
+        'match': '\\\\(\\d{1,3}|[abfnrtv\\\\"\'])|(\\\\.)'
+        'name': 'constant.character.escape.lua'
+        'captures':
+          '2':
+            'name': 'invalid.illegal.character.escape.lua'
+      }
+    ]
 'patterns': [
   {
     'captures':
@@ -45,8 +56,7 @@
         'include': 'punctuation.definition.string.end.lua'
       }
       {
-        'match': '\\\\.'
-        'name': 'constant.character.escape.lua'
+        'include': '#characterEscape'
       }
     ]
   }
@@ -68,8 +78,7 @@
         'include': 'punctuation.definition.string.end.lua'
       }
       {
-        'match': '\\\\.'
-        'name': 'constant.character.escape.lua'
+        'include': '#characterEscape'
       }
     ]
   }


### PR DESCRIPTION
- support decimal escape sequences (`\027`)
- highlight invalid escape sequences with invalid.illegal (`\c`)
