### PR TITLE
Add goto to the list of control keywords

### DIFF
--- a/grammars/lua.cson
+++ b/grammars/lua.cson
@@ -133,7 +133,7 @@
     ]
   }
   {
-    'match': '\\b(and|or|not|break|do|else|for|if|elseif|return|then|repeat|while|until|end|function|local|in)\\b'
+    'match': '\\b(and|or|not|break|do|else|for|if|elseif|return|then|repeat|while|until|end|function|local|in|goto)\\b'
     'name': 'keyword.control.lua'
   }
   {


### PR DESCRIPTION
The goto statement was added in Lua 5.2.0-beta-rc1.

Closes #21.

![preview](https://cloud.githubusercontent.com/assets/11627131/11626234/7df25f02-9ce1-11e5-9d61-dbfdb40dc998.png)