### PR TITLE
Attempt improving indentation

### DIFF
--- a/settings/language-lua.cson
+++ b/settings/language-lua.cson
@@ -1,5 +1,5 @@
 '.source.lua':
   'editor':
     'commentStart': '-- '
-    'increaseIndentPattern': '\\b(else|elseif|(local\\s+)?function|then|do|repeat)\\b((?!end).)*$|\\{\\s*$'
-    'decreaseIndentPattern': '^\\s*(elseif|else|end|until,?|\\}\\)?).*$'
+    'increaseIndentPattern': '((\\b(else|function|then|do|repeat)\\b((?!\\b(end|until)\\b).)*)|(\\{\\s*))$'
+    'decreaseIndentPattern': '^\\s*((\\b(elseif|else|end|until)\\b)|(\\})|(\\)))'


### PR DESCRIPTION
This change tries to make
- single line repeat-until not indent
- 'end' not match in the middle of words like 'tend'

Closes https://github.com/FireZenk/language-lua/issues/12

Would be nice if other people could also test this with various scripts as I might have missed something / altered some behavior.
I tested with some of my old scripts and they seemed to work fine. In fact spotted a mistake in my own indentation.


Example codes of fixed stuff:
Expected:
```lua
function Tend()
    -- code
end
```
Actual result:
```lua
function Tend()
-- code
end
```

Expected:
```lua
repeat code() until cond
-- more code
```
Actual result:
```lua
repeat code() until cond
    -- more code
```