### PR TITLE
Add syntax highlighting for constants

### DIFF
--- a/grammars/lua.cson
+++ b/grammars/lua.cson
@@ -137,7 +137,7 @@
     'name': 'keyword.control.lua'
   }
   {
-    'match': '(?<![^.]\\.|:)\\b(false|nil|true|_G|_VERSION|math\\.(pi|huge))\\b|(?<![.])\\.{3}(?!\\.)'
+    'match': '(?<![^.]\\.|:)\\b([A-Z_]+|false|nil|true|math\\.(pi|huge))\\b|(?<![.])\\.{3}(?!\\.)'
     'name': 'constant.language.lua'
   }
   {


### PR DESCRIPTION
Following the style of lua's default constants we highlight variables
which are written in ALL_CAPS connected by underscores.

![bildschirmfoto 2016-06-30 um 01 39 23](https://cloud.githubusercontent.com/assets/11627131/16472328/833aaf5e-3e63-11e6-80bd-edd6f38b7f5c.png)
